### PR TITLE
Fixing multiple stored XSS

### DIFF
--- a/includes/admin/components/login-widget/wsl.components.loginwidget.setup.php
+++ b/includes/admin/components/login-widget/wsl.components.loginwidget.setup.php
@@ -157,7 +157,7 @@ function wsl_component_loginwidget_setup_advanced_settings()
 		  <tr>
 			<td width="180" align="right"><strong><?php _wsl_e("Redirect URL", 'wordpress-social-login') ?> :</strong></td>
 			<td>
-				<input type="text" name="wsl_settings_redirect_url" class="inputgnrc" style="width:535px" value="<?php echo get_option( 'wsl_settings_redirect_url' ); ?>">
+				<input type="text" name="wsl_settings_redirect_url" class="inputgnrc" style="width:535px" value="<?php echo esc_html(get_option( 'wsl_settings_redirect_url' )); ?>">
 			</td>
 		  </tr>
 		  <tr>

--- a/includes/admin/components/login-widget/wsl.components.loginwidget.setup.php
+++ b/includes/admin/components/login-widget/wsl.components.loginwidget.setup.php
@@ -79,7 +79,7 @@ function wsl_component_loginwidget_setup_basic_settings()
 		  <tr>
 			<td width="180" align="right"><strong><?php _wsl_e("Connect with caption", 'wordpress-social-login') ?> :</strong></td>
 			<td>
-			<input type="text" class="inputgnrc" style="width:535px" value="<?php _wsl_e( get_option( 'wsl_settings_connect_with_label' ), 'wordpress-social-login' ); ?>" name="wsl_settings_connect_with_label" >
+			<input type="text" class="inputgnrc" style="width:535px" value="<?php esc_html_e( get_option( 'wsl_settings_connect_with_label' ), 'wordpress-social-login' ); ?>" name="wsl_settings_connect_with_label" >
 			</td>
 		  </tr>
 		  <tr>

--- a/includes/admin/components/networks/wsl.components.networks.setup.php
+++ b/includes/admin/components/networks/wsl.components.networks.setup.php
@@ -176,7 +176,7 @@ function wsl_component_networks_setup()
 							<?php if ( $require_client_id ){ // key or id ? ?>
 								<tr valign="top" <?php if( ! get_option( 'wsl_settings_' . $provider_id . '_enabled' ) ) echo 'style="display:none"'; ?> class="wsl_tr_settings_<?php echo $provider_id; ?>" >
 									<td><?php _wsl_e("Application ID", 'wordpress-social-login') ?>:</td>
-									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_id' ?>" value="<?php echo get_option( 'wsl_settings_' . $provider_id . '_app_id' ); ?>" ></td>
+									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_id' ?>" value="<?php echo esc_html(get_option( 'wsl_settings_' . $provider_id . '_app_id' )); ?>" ></td>
 									<td><a href="javascript:void(0)" onClick="toggleproviderhelp('<?php echo $provider_id; ?>')"><?php _wsl_e("Where do I get this info?", 'wordpress-social-login') ?></a></td>
 								</tr>
 							<?php } ?>
@@ -184,7 +184,7 @@ function wsl_component_networks_setup()
 							<?php if( !$require_client_id || $require_client_id === 'both' ) { ?>
 								<tr valign="top" <?php if( ! get_option( 'wsl_settings_' . $provider_id . '_enabled' ) ) echo 'style="display:none"'; ?> class="wsl_tr_settings_<?php echo $provider_id; ?>" >
 									<td><?php _wsl_e("Application Key", 'wordpress-social-login') ?>:</td>
-									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_key' ?>" value="<?php echo get_option( 'wsl_settings_' . $provider_id . '_app_key' ); ?>" ></td>
+									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_key' ?>" value="<?php echo esc_html(get_option( 'wsl_settings_' . $provider_id . '_app_key' )); ?>" ></td>
 									<td><a href="javascript:void(0)" onClick="toggleproviderhelp('<?php echo $provider_id; ?>')"><?php _wsl_e("Where do I get this info?", 'wordpress-social-login') ?></a></td>
 								</tr>
 							<?php }; ?>
@@ -192,7 +192,7 @@ function wsl_component_networks_setup()
 							<?php if( ! $require_api_key ) { ?>
 								<tr valign="top" <?php if( ! get_option( 'wsl_settings_' . $provider_id . '_enabled' ) ) echo 'style="display:none"'; ?> class="wsl_tr_settings_<?php echo $provider_id; ?>" >
 									<td><?php _wsl_e("Application Secret", 'wordpress-social-login') ?>:</td>
-									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_secret' ?>" value="<?php echo get_option( 'wsl_settings_' . $provider_id . '_app_secret' ); ?>" ></td>
+									<td><input dir="ltr" type="text" name="<?php echo 'wsl_settings_' . $provider_id . '_app_secret' ?>" value="<?php echo esc_html(get_option( 'wsl_settings_' . $provider_id . '_app_secret' )); ?>" ></td>
 									<td><a href="javascript:void(0)" onClick="toggleproviderhelp('<?php echo $provider_id; ?>')"><?php _wsl_e("Where do I get this info?", 'wordpress-social-login') ?></a></td>
 								</tr>
 							<?php } ?>


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-other-wordpress-social-login/

### ⚙️ Description *

Utilizing the esc_html function to prevent html content to be outputted without sanitazation. This prevents malicious user from inserting scripts to steal password, sesscions etc.

### 🐛 Proof of Concept (PoC) *

Replay the Poc. no more alert boxes

### 🔥 Proof of Fix (PoF) *

1) Install the Plugin from https://github.com/miled/wordpress-social-login
2) Go to settings Page Widget Tab
3) Insert "><script>alert(123)</script>
4) Hit save. XSS will fire
5) Go to yourwordpress.com/wp-admin and see XSS fired also here

POC Video:
https://d.pr/v/8GqACk


